### PR TITLE
Update TEI_nested_Torso_Article

### DIFF
--- a/TEI_nested_Torso_Article
+++ b/TEI_nested_Torso_Article
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<TEI>
+<?xml-model href="http://www.tei-c.org/release/xml/tei/custom/schema/relaxng/tei_all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="http://www.tei-c.org/release/xml/tei/custom/schema/relaxng/tei_all.rng" type="application/xml"
+	schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
     <teiHeader>
         <fileDesc>
             <titleStmt>


### PR DESCRIPTION
There was no namespace or schema declaration, that is way the file was not displaying the validation errors. Now you should be able to see that validating against tei_all there is an error.