### PR TITLE
pylonFormatting.xsl (version 1.1)

### DIFF
--- a/xslt/pylonFormatting.xsl
+++ b/xslt/pylonFormatting.xsl
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns="http://www.tei-c.org/ns/1.0" xpath-default-namespace="http://www.tei-c.org/ns/1.0" version="3.0">
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns="http://www.tei-c.org/ns/1.0"
+  xpath-default-namespace="http://www.tei-c.org/ns/1.0" version="3.0">
   <!--2018-06-13 ebb: XSLT-Identity Transformation Starter (non-namespaced XML)
   Template provided by Elisa Beshero-Bondar for the 2024 Digital Humanities Summer Institute, University of Victoria
-  Developed by C.M. Sampson to provide additional processing of Pylon XML, following conversion by Hugh Cayless's .docx to .xml converter (https://github.com/hcayless/P3-processing) 
+  Developed by C.M. Sampson to provide additional processing of Pylon XML prior to publication, immediately following conversion by Hugh Cayless's .docx to .xml converter (https://github.com/hcayless/P3-processing) 
   -->
 
   <xsl:output method="xml" indent="yes"/>
@@ -13,15 +14,12 @@
     ================
     <seg> wrangling
     ================
-    Possible @style for <seg>
-    - "font-weight: bold;"
-    - "font-style: italic;"
-    - "text-decoration: underline;"
-    - AND all combinations thereof
-    - so far in Pylon, we have seen
-        - "font-weight: bold;"
-        - "font-style: italic;"
-        - "text-decoration: underline;"
+    
+    - <seg style="font-weight: bold;"> => <emph rend="bold"> 
+    - <seg style="font-style: italic;"> => <emph rend="italics">
+    - <seg style="text-decoration: underline;"> => <emph rend="underlined">
+    
+    - NB: combinations are possible, e.g.
         - "font-weight: bold;text-decoration: underline;"
         - "font-style: italic;text-decoration: underline;"
         - "font-style: italic;font-weight: bold;"
@@ -45,13 +43,7 @@
 
   <!--
     ================
-    Remove alignment @style junk in <p> 
-    ================
-    ================
-    Hyphens between numerals
-    ================
-    ================
-    Dimensions x => × 
+    Remove @style from <p> 
     ================
   -->
   <xsl:template match="p">
@@ -60,72 +52,45 @@
       <xsl:apply-templates select="node()"/>
     </p>
   </xsl:template>
-  <xsl:template match="p/text() | bibl/text() | head/text() | cell/text()">
+  <!--
+    ================
+    En-dash between numerals instead of hyphens 
+    ================
+  -->
+  <xsl:template match="p/text() | bibl/text()">
     <xsl:analyze-string select="." regex="\d-\d">
       <xsl:matching-substring>
-        <xsl:analyze-string select="replace(., '-', '–')" regex="\sx\s">
-          <xsl:matching-substring>
-            <xsl:value-of select="concat(' ', normalize-space(replace(., 'x', '×')), ' ')"/>
-          </xsl:matching-substring>
-          <xsl:non-matching-substring>
-            <xsl:value-of select="."/>
-          </xsl:non-matching-substring>
-        </xsl:analyze-string>
+        <xsl:value-of select="replace(., '-', '–') ! normalize-space()"/>
       </xsl:matching-substring>
       <xsl:non-matching-substring>
-        <xsl:analyze-string select="." regex="\sx\s">
-          <xsl:matching-substring>
-            <xsl:value-of select="concat(' ', normalize-space(replace(., 'x', '×')), ' ')"/>
-          </xsl:matching-substring>
-          <xsl:non-matching-substring>
-            <xsl:value-of select="."/>
-          </xsl:non-matching-substring>
-        </xsl:analyze-string>
+        <xsl:value-of select="."/>
       </xsl:non-matching-substring>
     </xsl:analyze-string>
+
+    <!--
+      ================
+      Conversion to 'smart' quotes and curly apostrophes
+      NOT YET OPERATIONAL
+      ================
+      <xsl:key name="idnoLookup" match="file" use="idno[@type = 'ddb-hybrid']"/>
+      <xsl:analyze-string select="." regex="[&quot;'']">
+      <xsl:matching-substring>
+        <xsl:value-of select="replace(., '-', '–') ! normalize-space()"/>
+      </xsl:matching-substring>
+      <xsl:non-matching-substring>
+        <xsl:value-of select="."/>
+      </xsl:non-matching-substring>
+    </xsl:analyze-string>-->
   </xsl:template>
 
   <!--
     ================
-    Add xml:ids to line numbers in the editions
+    Trimming <ref target="https://papyri.info/biblio/"> 
+    of unwanted search junk
     ================
   -->
-  <xsl:template match="ab/lb">
-    <xsl:copy>
-      <xsl:attribute name="xml:id">
-        <xsl:value-of select="concat(ancestor::div/@xml:id, 'ln', @n)"/>
-      </xsl:attribute>
-      <xsl:apply-templates select="@* | node()"/>
-    </xsl:copy>
-  </xsl:template>
 
-  <!--
-    ================
-    repository => collection 
-    (and adding other requisite msIdentifier elements)
-    ================
-  -->
-  <xsl:template match="msIdentifier">
-    <msIdentifier>
-      <placeName>
-        <settlement/>
-      </placeName>
-      <collection/>
-      <idno type="invNo">
-        <xsl:value-of select="./idno[@type = 'invNo']"/>
-      </idno>
-    </msIdentifier>
-
-  </xsl:template>
-  
-  <!--
-    ================
-    Trimming <ref[@target="https://papyri.info/...]"> 
-    urls of unwanted search junk
-    ================
-  -->
-  
-  <xsl:template match="ref[contains(@target, 'papyri.info') and contains(@target, '?')]">
+  <xsl:template match="ref[matches(@target, 'papyri.info/biblio/\d+\?')]">
     <ref>
       <xsl:attribute name="target">
         <xsl:value-of select="substring-before(@target, '?')"/>
@@ -133,6 +98,7 @@
       <xsl:apply-templates select="node()"/>
     </ref>
   </xsl:template>
+
   
   <!--
     ================
@@ -146,26 +112,43 @@
       <xsl:apply-templates select="node()"/>
     </ref>
   </xsl:template>
-  
 
   <!--
     ================
-    Hyperlink automated lookup: NOT YET OPERATIONAL
+    Add @xml:id values to <lb/> within editions
     ================
-    <xsl:key name="idnoLookup" match="file" use="idno[@type='ddb-hybrid']" />
-       
-    ================
-    Conversion to 'smart' quotes and curly apostrophes
-    ================
-      <xsl:analyze-string select="." regex="[&quot;'']">
-      <xsl:matching-substring>
-        <xsl:value-of select="replace(., '-', '–') ! normalize-space()"/>
-      </xsl:matching-substring>
-      <xsl:non-matching-substring>
-        <xsl:value-of select="."/>
-      </xsl:non-matching-substring>
-    </xsl:analyze-string>  
   -->
-
+  <xsl:template match="div[@type='edition']//lb">
+    <xsl:variable name="ancestor-id" select="ancestor::div[@type='edition'][1]/@xml:id"/>
+    <xsl:variable name="ancestor-n-values">
+      <xsl:for-each select="ancestor::div/@n">
+        <xsl:value-of select="concat('', .)"/>
+      </xsl:for-each>
+    </xsl:variable>
+    <xsl:copy>
+      <xsl:attribute name="xml:id">
+        <xsl:value-of select="concat($ancestor-id, $ancestor-n-values, 'ln', @n)"/>
+      </xsl:attribute>
+      <xsl:apply-templates select="@*|node()"/>
+    </xsl:copy>
+  </xsl:template>
+ 
+  <!--
+    ================
+    Place the lemma <ref> above <p> within div[@type='commentary']/<note>
+    ================
+  -->
+  <xsl:template match="div[@type='commentary']/note">
+    <xsl:copy>
+      <xsl:apply-templates select="p/ref[not(@*)]"/>
+      <xsl:apply-templates select="*"/>
+    </xsl:copy>
+  </xsl:template>
+  
+  <xsl:template match="div[@type='commentary']/note/p">
+    <xsl:copy>
+      <xsl:apply-templates select="@* | node()[not(self::ref[not(@*)])]"/>
+    </xsl:copy>
+  </xsl:template>
 
 </xsl:stylesheet>


### PR DESCRIPTION
This file is a second attempt at automating via XSLT various basic changes that are necessary following the conversion to XML of a .docx accepted for publication in Pylon. Comments within the file describe these changes, but I list them here, as well, for the sake of reference.

- `<seg style="font-weight: bold;">` => `<emph rend="bold"> `

- `<seg style="font-style: italic;">` => `<emph rend="italics">`
 
- `<seg style="text-decoration: underline;">` => `<emph rend="underlined">`
 
- remove `@style` from `<p>`
 
- remove `@xml:space="preserve"` from `<ref>`
 
- replace hyphens between numerals within `<p>`, `<bibl>`, `<head>`, and `<cell>` elements with en-dashes
 
- replace ` x ` (to indicate dimensions) within `<p>`, `<bibl>`, `<head>`, and `<cell>` elements with ` × `
 
- trim the `<ref target="https://papyri.info/...">` URL of any query parameters and API details
 
- Add `@xml:id` to line numbers in the editions, which incorporates the `@n` value of any `ancestor::div`, too
 
- various bits of `<msIdentifier>` not handled properly by Hugh's converter

NB: this XSLT no longer duplicates the `<div>` of a text edition (with `@subtype="Pylon"` and `@subtype="PN"`), as v. 1.0 did. It is easier to add the necessary markup for heiEDITIONS XML at this phase, and then remove it via XSLT for transfer to `papyri.info`.